### PR TITLE
Wait for transaction commit after deleting each subvolume

### DIFF
--- a/lib/fs/btrfs.go
+++ b/lib/fs/btrfs.go
@@ -79,7 +79,7 @@ func SubvolumeDestroy(path string) {
 	}
 	qgroupDestroy(id(path))
 
-	out, err := exec.Command("btrfs", "subvolume", "delete", path).CombinedOutput()
+	out, err := exec.Command("btrfs", "subvolume", "delete", "-C", path).CombinedOutput()
 	log.Check(log.DebugLevel, "Destroying subvolume "+path+": "+string(out), err)
 }
 


### PR DESCRIPTION
Append `-C` option to `btrfs subvolume delete` command line so that btrfs transactions are committed after deleting each subvolume, and when the command returns agent could be sure there's no race condition. This reduces the speed for deleting subvolume for a bit (<1 second each subvolume), which may accumulate when there are a large amount of them to be destroyed, but considering the maximum amount of containers on a single host are typically less than 1000 and aren't normally trashed together, the extended time of deletion is acceptable.