### PR TITLE
Jenkinsfile: fix checking out of existing branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ try {
 			# Clone agent code
 			git clone https://github.com/subutai-io/agent
 			cd agent
-			git checkout --track origin/${release}
+			git checkout ${release}
 		"""		
 		stage("Tweaks for version")
 		notifyBuildDetails = "\nFailed on Stage - Version tweaks"


### PR DESCRIPTION
On old version of git, checking out a branch that's not created locally
will have to use --track option, but in recent version this behaviour
has been changed to set up tracking branch automatically.