### PR TITLE
Jenkinsfile: update date string

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ try {
 		notifyBuildDetails = "\nFailed on Stage - Version tweaks"
 		sh """
                         cd ${CWD}/agent || exit 1
-                        agent_version=\$(git describe --abbrev=0 --tags)+\$(date +%Y%m%d%H%M%S)
+                        agent_version=\$(git describe --abbrev=0 --tags)+\$(date +%Y%m%d%H%M%S0)
 			echo "VERSION is \$agent_version"
 
 			cd ${CWD}/agent && sed -i 's/quilt/native/' debian/source/format


### PR DESCRIPTION
Takes 2 for getting the date string fixed correctly. The date command's output is in different precision with groovy, but in sysnet branch it succeeded because of being lucky of the string is smaller. This commit fixes the string comparison.