### PR TITLE
cfg fix

### DIFF
--- a/debian/tree/agent.conf
+++ b/debian/tree/agent.conf
@@ -1,7 +1,6 @@
 [Agent]
 Debug = true
 GpgUser =
-AppPrefix = /usr/share/subutai/
 LxcPrefix = /var/lib/lxc/
 Dataset = subutai/fs
 DataPrefix = /var/lib/subutai/


### PR DESCRIPTION
removed obsolete setting from agent.conf that caused agent to fail config loading and skip it